### PR TITLE
Adapt ember-modules-codemod to ember-data needs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/__testfixtures__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Ember Data Codemod
+
+:warning: this is a work in progress :warning:
+
+This codemod uses [`jscodeshift`](https://github.com/facebook/jscodeshift) to update an Ember application to import ember-data code using the new module syntax, as proposed in [RFC 395: @ember-data packages](https://github.com/emberjs/rfcs/pull/395). It can update apps that use legacy imports from `ember-data` and from the global `DS`.
+
+This repository is heavily inspired (if not copied and adapted) by [ember-modules-codemod](https://github.com/ember-cli/ember-modules-codemod). [This PR](https://github.com/dcyriller/ember-data-codemod/pull/1) illustrates the work needed to adapt ember-modules-codemod to fit ember-data needs.
+
+## Usage
+
+```sh
+npx github:dcyriller/ember-data-codemod
+```

--- a/__testfixtures__/final-boss.input.js
+++ b/__testfixtures__/final-boss.input.js
@@ -1,0 +1,30 @@
+//  Test cases:
+//  * This comment gets preserved at the top of the file.
+//  * Re-uses existing aliases if already specified
+//  * Chooses appropriate alias if not specified
+//  * Adds default export to named exports if they already exist
+//  * Adds named exports to default export if it already exists
+//  * Variables named `DS` are not considered
+//  * Manual aliasing (`var Adapter = DS.Adapter` is removed)
+//  * `DS` must be the root of property lookups (no `foo.DS.bar`)
+//  * Renamed destructured aliases are preserved (`attr: thing`)
+import Nodel from "@ember-data/model";
+import DS from 'ember-data';
+
+let bar = foo.DS.attr;
+
+const Adapter = DS.Adapter;
+
+const {
+  attr: thing
+} = DS;
+
+export default DS.Model.extend({
+  shoe: thing('number')
+});
+
+(function() {
+  let DS = {};
+  DS.Model = class Adapter {
+  };
+})();

--- a/__testfixtures__/final-boss.output.js
+++ b/__testfixtures__/final-boss.output.js
@@ -1,0 +1,23 @@
+//  Test cases:
+//  * This comment gets preserved at the top of the file.
+//  * Re-uses existing aliases if already specified
+//  * Chooses appropriate alias if not specified
+//  * Adds default export to named exports if they already exist
+//  * Adds named exports to default export if it already exists
+//  * Variables named `DS` are not considered
+//  * Manual aliasing (`var Adapter = DS.Adapter` is removed)
+//  * `DS` must be the root of property lookups (no `foo.DS.bar`)
+//  * Renamed destructured aliases are preserved (`attr: thing`)
+import Nodel, { attr as thing } from "@ember-data/model";
+
+let bar = foo.DS.attr;
+
+export default Nodel.extend({
+  shoe: thing('number')
+});
+
+(function() {
+  let DS = {};
+  DS.Model = class Adapter {
+  };
+})();

--- a/__testfixtures__/leave-destructured-name.input.js
+++ b/__testfixtures__/leave-destructured-name.input.js
@@ -1,0 +1,4 @@
+const { attr: thing } = DS;
+
+thing('string');
+DS.attr('string');

--- a/__testfixtures__/leave-destructured-name.output.js
+++ b/__testfixtures__/leave-destructured-name.output.js
@@ -1,0 +1,4 @@
+import { attr as thing } from '@ember-data/model';
+
+thing('string');
+thing('string');

--- a/__testfixtures__/named-then-default-imports.input.js
+++ b/__testfixtures__/named-then-default-imports.input.js
@@ -1,0 +1,2 @@
+DS.AdapterError;
+DS.AbortError;

--- a/__testfixtures__/named-then-default-imports.output.js
+++ b/__testfixtures__/named-then-default-imports.output.js
@@ -1,0 +1,3 @@
+import AdapterError, { AbortError } from '@ember-data/adapter/error';
+AdapterError;
+AbortError;

--- a/__testfixtures__/remove-ds-import.input.js
+++ b/__testfixtures__/remove-ds-import.input.js
@@ -1,4 +1,4 @@
 import DS from 'ember-data';
 
-export default Ember.Model.extend({
+export default DS.Model.extend({
 }); 

--- a/__testfixtures__/remove-ds-import.output.js
+++ b/__testfixtures__/remove-ds-import.output.js
@@ -1,4 +1,4 @@
-import Model from '@ember-data/Model';
+import Model from '@ember-data/model';
 
 export default Model.extend({
 });

--- a/__testfixtures__/top-comment.input.js
+++ b/__testfixtures__/top-comment.input.js
@@ -1,0 +1,7 @@
+/**
+ * This comment should be preserved, and included before the inserted import statements.
+ */
+import DS from 'ember-data';
+
+export default DS.Adapter.extend({
+});

--- a/__testfixtures__/top-comment.output.js
+++ b/__testfixtures__/top-comment.output.js
@@ -1,0 +1,7 @@
+/**
+ * This comment should be preserved, and included before the inserted import statements.
+ */
+import Adapter from '@ember-data/adapter';
+
+export default Adapter.extend({
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "ember-data-rfc395-data": "github:ember-data/ember-data-rfc395-data",
+    "ember-data-rfc395-data": "github:dcyriller/ember-data-rfc395-data#finish-mappings",
     "execa": "^1.0.0",
     "glob": "^7.1.3",
     "jscodeshift": "^0.3.29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-"ember-data-rfc395-data@github:ember-data/ember-data-rfc395-data":
+"ember-data-rfc395-data@github:dcyriller/ember-data-rfc395-data#finish-mappings":
   version "0.0.0"
-  resolved "https://codeload.github.com/ember-data/ember-data-rfc395-data/tar.gz/ea5ddff604d358927ce0fba3fa1f03701487a999"
+  resolved "https://codeload.github.com/dcyriller/ember-data-rfc395-data/tar.gz/5ffc1d36824a4560db031579e3f3c887b385302b"
 
 emoji-regex@^7.0.1:
   version "7.0.3"


### PR DESCRIPTION
This PR adapts the code extracted from ember-modules-codemod to fit ember-data needs for [RFC 395: @ember-data packages](https://github.com/emberjs/rfcs/blob/master/text/0395-ember-data-packages.md).

The diff is pretty large. And adapting ember-modules-codemod to fit both ember and ember-data modules seems challenging to me. With some additional work and guidance, I may be able to do it. But for now, you can find here a naive implementation (that may be enough?).