### PR TITLE
Fix missing import

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true
+};

--- a/__testfixtures__/final-boss.output.js
+++ b/__testfixtures__/final-boss.output.js
@@ -8,6 +8,8 @@
 //  * Manual aliasing (`var Adapter = DS.Adapter` is removed)
 //  * `DS` must be the root of property lookups (no `foo.DS.bar`)
 //  * Renamed destructured aliases are preserved (`attr: thing`)
+import Adapter from '@ember-data/adapter';
+
 import Nodel, { attr as thing } from "@ember-data/model";
 
 let bar = foo.DS.attr;

--- a/__testfixtures__/leave-destructured-import.input.js
+++ b/__testfixtures__/leave-destructured-import.input.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+const { Model } = DS;
+
+export default Model.extend({
+
+});

--- a/__testfixtures__/leave-destructured-import.output.js
+++ b/__testfixtures__/leave-destructured-import.output.js
@@ -1,0 +1,5 @@
+import Model from '@ember-data/model';
+
+export default Model.extend({
+
+});

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -55,7 +55,7 @@ function transform(file, api /*, options*/) {
     // Resolve the discovered aliases against the module registry. We intentionally do
     // this ahead of finding replacements for e.g. `DS.Model` usage in
     // order to reuse custom names for any fields referenced both ways.
-    resolveAliasImports(globalAliases, mappings, modules, root);
+    resolveAliasImports(globalAliases, mappings, modules);
 
     // Scan the source code, looking for any instances of the `DS` identifier
     // used as the root of a property lookup. If they match one of the provided
@@ -312,27 +312,16 @@ function transform(file, api /*, options*/) {
     return aliases;
   }
 
-  function resolveAliasImports(aliases, mappings, registry, root) {
+  function resolveAliasImports(aliases, mappings, registry) {
     for (let globalName of Object.keys(aliases)) {
       let alias = aliases[globalName];
       let mapping = mappings[alias.dsPath];
-      if (hasSimpleCallExpression(root, alias.identifier.node.name)) {
-        registry.get(
-          mapping.source,
-          mapping.imported,
-          alias.identifier.node.name
-        );
-      }
+      registry.get(
+        mapping.source,
+        mapping.imported,
+        alias.identifier.node.name
+      );
     }
-  }
-
-  function hasSimpleCallExpression(root, name) {
-    let paths = root.find(j.CallExpression, {
-      callee: {
-        name
-      }
-    });
-    return paths.length > 0;
   }
 
   /**


### PR DESCRIPTION
Previously,
```
import DS from 'ember-data';
const { Model } = DS;

export default Model.extend({

});
```
was turned into:
```
export default Model.extend({

});
```

Now:
```
import Model from '@ember-data/model';

export default Model.extend({

});
```