### PR TITLE
WIP: Update mappings to a trimmed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "ember-data-rfc395-data": "github:ember-data/ember-data-rfc395-data#v0.0.2",
+    "@ember-data/rfc395-data": "github:ember-data/ember-data-rfc395-data",
     "execa": "^1.0.0",
     "glob": "^7.1.3",
     "jscodeshift": "^0.3.29"

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fs = require('fs');
-const MAPPINGS = require('ember-data-rfc395-data');
+const MAPPINGS = require('@ember-data/rfc395-data');
 
 const LOG_FILE = 'ember-data-codemod.tmp.' + process.pid;
 const ERROR_WARNING = 1;

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -112,12 +112,10 @@ function transform(file, api /*, options*/) {
     let mappings = {};
 
     for (let mapping of MAPPINGS) {
-      if (!mapping.deprecated) {
-        mappings[mapping.global.substr('DS.'.length)] = new Mapping(
-          mapping,
-          registry
-        );
-      }
+      mappings[mapping.global.substr('DS.'.length)] = new Mapping(
+        mapping,
+        registry
+      );
     }
 
     return mappings;
@@ -673,8 +671,8 @@ class Replacement {
 
 class Mapping {
   constructor(options, registry) {
-    this.source = options.module;
-    this.imported = options.export;
+    this.source = options.replacement.module;
+    this.imported = options.replacement.export;
     this.local = options.localName;
     this.registry = registry;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ember-data/rfc395-data@github:ember-data/ember-data-rfc395-data":
+  version "0.0.2"
+  resolved "https://codeload.github.com/ember-data/ember-data-rfc395-data/tar.gz/acaaa4e9c832067deb0d11295b1ef30ea8c3358f"
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -2079,10 +2083,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-"ember-data-rfc395-data@github:ember-data/ember-data-rfc395-data#v0.0.2":
-  version "0.0.2"
-  resolved "https://codeload.github.com/ember-data/ember-data-rfc395-data/tar.gz/e1c221f4c29922fa6a61a6b89032392c4c2dcea0"
 
 emoji-regex@^7.0.1:
   version "7.0.3"


### PR DESCRIPTION
## Description

This PR updates the mappings consumed by this codemod to a trimmed version.

## Details

Previously, some mappings were duplicated. For instance, `DS.Adpater` would be specified like this:
```
  {
    "global": "DS.Adapter",
    "module": "@ember-data/adapter",
    "export": "default",
    "localName": "Adapter",
    "deprecated": false
},
```
and like this:
```
  {
    "global": "DS.Adapter",
    "module": "ember-data/adapter",
    "export": "default",
    "deprecated": true,
    "replacement": {
      "module": "@ember-data/adapter",
      "export": "default"
    }
},
```

The new https://github.com/ember-data/ember-data-rfc395-data release will contain the second version only.

Why this duplication you may ask.

The goal was to stick to https://github.com/ember-cli/ember-rfc176-data mappings' current structure. To ease the codemod development by leveraging what has been done for https://github.com/ember-codemods/ember-modules-codemod. Now that the development is done, we may safely remove the duplicated data structures.

## Manual testing

Here a repository I use to manual test the changes: https://github.com/dcyriller/__ember-app-data-imports/tree/master/app/models

## Note

After @ember-data/rfc395-data release, the WIP will be removed.