### PR TITLE
Update literal paths

### DIFF
--- a/__testfixtures__/literal.input.js
+++ b/__testfixtures__/literal.input.js
@@ -1,4 +1,5 @@
-import Model, { attrs } from 'ember-data/model';
+import Model, { attr } from 'ember-data/model';
 import { hasMany, belongsTo } from 'ember-data/relationships';
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import { InvalidError, ServerError, TimeoutError, NotFoundError  } from 'ember-data/adapter/error';
+import Transform from '@ember-data/serializer/transform';

--- a/__testfixtures__/literal.input.js
+++ b/__testfixtures__/literal.input.js
@@ -1,4 +1,5 @@
-import Model, { attr } from 'ember-data/model';
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
 import { hasMany, belongsTo } from 'ember-data/relationships';
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import { InvalidError, ServerError, TimeoutError, NotFoundError  } from 'ember-data/adapter/error';

--- a/__testfixtures__/literal.input.js
+++ b/__testfixtures__/literal.input.js
@@ -1,0 +1,4 @@
+import Model, { attrs } from 'ember-data/model';
+import { hasMany, belongsTo } from 'ember-data/relationships';
+import JSONAPIAdapter from 'ember-data/adapters/json-api';
+import { InvalidError, ServerError, TimeoutError, NotFoundError  } from 'ember-data/adapter/error';

--- a/__testfixtures__/literal.output.js
+++ b/__testfixtures__/literal.output.js
@@ -1,0 +1,5 @@
+import Model, { attrs } from '@ember-data/model';
+import { hasMany, belongsTo } from '@ember-data/model';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import { InvalidError, ServerError, TimeoutError, NotFoundError  } from '@ember-data/adapter/error';
+

--- a/__testfixtures__/literal.output.js
+++ b/__testfixtures__/literal.output.js
@@ -1,4 +1,4 @@
-import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { InvalidError, ServerError, TimeoutError, NotFoundError  } from '@ember-data/adapter/error';
 import Transform from '@ember-data/serializer/transform';

--- a/__testfixtures__/literal.output.js
+++ b/__testfixtures__/literal.output.js
@@ -3,4 +3,3 @@ import { hasMany, belongsTo } from '@ember-data/model';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { InvalidError, ServerError, TimeoutError, NotFoundError  } from '@ember-data/adapter/error';
 import Transform from '@ember-data/serializer/transform';
-

--- a/__testfixtures__/literal.output.js
+++ b/__testfixtures__/literal.output.js
@@ -1,5 +1,4 @@
-import Model, { attr } from '@ember-data/model';
-import { hasMany, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { InvalidError, ServerError, TimeoutError, NotFoundError  } from '@ember-data/adapter/error';
 import Transform from '@ember-data/serializer/transform';

--- a/__testfixtures__/literal.output.js
+++ b/__testfixtures__/literal.output.js
@@ -1,5 +1,6 @@
-import Model, { attrs } from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 import { hasMany, belongsTo } from '@ember-data/model';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { InvalidError, ServerError, TimeoutError, NotFoundError  } from '@ember-data/adapter/error';
+import Transform from '@ember-data/serializer/transform';
 

--- a/bin/ember-data-codemod.js
+++ b/bin/ember-data-codemod.js
@@ -11,7 +11,7 @@ let cwd = process.cwd();
 let pkgPath = path.join(cwd, 'package.json');
 
 const DEFAULT_PATHS = [
-  'app',
+  'app'
   'addon',
   'addon-test-support',
   'tests',
@@ -143,7 +143,7 @@ function buildReport() {
       );
     } else {
       console.log(
-        chalk.green('\nDone! All uses of the Ember global have been updated.')
+        chalk.green('\nDone! All uses of the Ember global and Ember Data imports have been updated.')
       );
     }
   });

--- a/bin/ember-data-codemod.js
+++ b/bin/ember-data-codemod.js
@@ -11,7 +11,7 @@ let cwd = process.cwd();
 let pkgPath = path.join(cwd, 'package.json');
 
 const DEFAULT_PATHS = [
-  'app'
+  'app',
   'addon',
   'addon-test-support',
   'tests',

--- a/bin/ember-data-codemod.js
+++ b/bin/ember-data-codemod.js
@@ -89,7 +89,7 @@ function buildReport() {
 
   // Find all of the temporary logs from the worker processes, which contain a
   // serialized JSON array on each line.
-  glob('ember-modules-codemod.tmp.*', (err, logs) => {
+  glob('ember-data-codemod.tmp.*', (err, logs) => {
     // If no worker found an unexpected value, nothing to report.
     if (!logs) {
       return;

--- a/bin/ember-data-codemod.js
+++ b/bin/ember-data-codemod.js
@@ -143,7 +143,9 @@ function buildReport() {
       );
     } else {
       console.log(
-        chalk.green('\nDone! All uses of the Ember global and Ember Data imports have been updated.')
+        chalk.green(
+          '\nDone! All uses of the Ember global and Ember Data imports have been updated.'
+        )
       );
     }
   });

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -190,7 +190,8 @@ function transform(file, api /*, options*/) {
     const uniqueImports = {};
 
     root.find(j.ImportDeclaration).forEach(nodePath => {
-      let value = nodePath.value && nodePath.value.source.value;
+      let node = nodePath.node;
+      let value = node.source && node.source.value;
 
       if (!(value in uniqueImports)) {
         // add to found uniqueImports and we wont modify
@@ -198,7 +199,7 @@ function transform(file, api /*, options*/) {
       } else {
         // get all specifiers and add to existing import
         // then delete this nodePath
-        let specifiers = nodePath.value && nodePath.value.specifiers;
+        let specifiers = node.specifiers;
         let existingNodePath = uniqueImports[value];
 
         specifiers.forEach(spec => {

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -161,6 +161,8 @@ function transform(file, api /*, options*/) {
   }
 
   /*
+   * loops through all modules and replaces literal path if necessary
+   * 'ember-data/model' -> '@ember-data/model'
    */
   function updateLiteralPaths(root, mappings, registry) {
     return registry.modules.map((module) => {

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -188,44 +188,41 @@ function transform(file, api /*, options*/) {
    */
   function cleanupDuplicateLiteralPaths() {
     const imports = {};
-    root.find(j.ImportDeclaration)
-      .forEach(nodePath => {
-        let value = nodePath.value && nodePath.value.source.value;
+    root.find(j.ImportDeclaration).forEach(nodePath => {
+      let value = nodePath.value && nodePath.value.source.value;
 
-        if (!(value in imports)) {
-          // add to found imports and we wont modify
-          imports[value] = nodePath;
-        } else {
-          // get all specifiers and add to existing import
-          // then delete this nodePath
-          let specifiers = nodePath.value && nodePath.value.specifiers;
-          let existingNodePath = imports[value];
+      if (!(value in imports)) {
+        // add to found imports and we wont modify
+        imports[value] = nodePath;
+      } else {
+        // get all specifiers and add to existing import
+        // then delete this nodePath
+        let specifiers = nodePath.value && nodePath.value.specifiers;
+        let existingNodePath = imports[value];
 
-          specifiers.forEach((spec) => {
-            let local = spec.local;
-            let imported = spec.imported;
+        specifiers.forEach(spec => {
+          let local = spec.local;
+          let imported = spec.imported;
 
-            if (imported === 'default') {
-              let specifier = j.importDefaultSpecifier(j.identifier(local));
-              // default imports go at front
-              existingNodePath.get('specifiers').unshift(specifier);
-            } else if (imported && local) {
-              let specifier = j.importSpecifier(
-                j.identifier(imported.name),
-                j.identifier(local.name)
-              );
-              existingNodePath.get('specifiers').push(specifier);
-            } else {
-              let specifier = j.importSpecifier(
-                j.identifier(local.name)
-              );
-              existingNodePath.get('specifiers').push(specifier);
-            }
-          });
+          if (imported === 'default') {
+            let specifier = j.importDefaultSpecifier(j.identifier(local));
+            // default imports go at front
+            existingNodePath.get('specifiers').unshift(specifier);
+          } else if (imported && local) {
+            let specifier = j.importSpecifier(
+              j.identifier(imported.name),
+              j.identifier(local.name)
+            );
+            existingNodePath.get('specifiers').push(specifier);
+          } else {
+            let specifier = j.importSpecifier(j.identifier(local.name));
+            existingNodePath.get('specifiers').push(specifier);
+          }
+        });
 
-          nodePath.prune()
-        }
-      });
+        nodePath.prune();
+      }
+    });
   }
 
   // Find destructured global aliases for fields on the DS global

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -67,7 +67,7 @@ function transform(file, api /*, options*/) {
     // Now that we've identified all of the replacements that we need to do, we'll
     // make sure to either add new `import` declarations, or update existing ones
     // to add new named exports or the default export.
-    updateOrCreateImportDeclarations(root, mappings, modules);
+    updateOrCreateImportDeclarations(root, modules, mappings);
 
     // Actually go through and replace each usage of `DS.whatever` with the
     // imported binding (`whatever`).
@@ -459,7 +459,7 @@ function transform(file, api /*, options*/) {
     return parent.node.id.name === local;
   }
 
-  function updateOrCreateImportDeclarations(root, mappings, registry) {
+  function updateOrCreateImportDeclarations(root, registry, mappings) {
     let body = root.get().value.program.body;
 
     registry.modules.forEach(mod => {

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -187,18 +187,19 @@ function transform(file, api /*, options*/) {
    * to make sure we clean up duplicate imports
    */
   function cleanupDuplicateLiteralPaths() {
-    const imports = {};
+    const uniqueImports = {};
+
     root.find(j.ImportDeclaration).forEach(nodePath => {
       let value = nodePath.value && nodePath.value.source.value;
 
-      if (!(value in imports)) {
-        // add to found imports and we wont modify
-        imports[value] = nodePath;
+      if (!(value in uniqueImports)) {
+        // add to found uniqueImports and we wont modify
+        uniqueImports[value] = nodePath;
       } else {
         // get all specifiers and add to existing import
         // then delete this nodePath
         let specifiers = nodePath.value && nodePath.value.specifiers;
-        let existingNodePath = imports[value];
+        let existingNodePath = uniqueImports[value];
 
         specifiers.forEach(spec => {
           let local = spec.local;
@@ -546,7 +547,7 @@ function transform(file, api /*, options*/) {
       updateExistingLiteralPaths(root, mod, mappings);
     });
 
-    // // then remove old duplicate specifier if found
+    // then remove old duplicate specifier if found
     cleanupDuplicateLiteralPaths();
   }
 

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -160,21 +160,25 @@ function transform(file, api /*, options*/) {
     return dsUsages.filter(isDSGlobal(globalDS)).paths();
   }
 
+  /*
+   */
   function updateLiteralPaths(root, mappings, registry) {
     return registry.modules.map((module) => {
       let foundMapping = mappings[module.local];
       if (foundMapping) {
         let newSource = foundMapping.source;
-        root.find(j.ImportDeclaration, {
-          source: {
-            type: 'Literal',
-            value: module.source
-          }
-        })
-        .find(j.Literal)
-        .forEach((importLiteral) => {
-          j(importLiteral).replaceWith(j.literal(newSource))
-        });
+        if (module.source !== newSource) {
+          root.find(j.ImportDeclaration, {
+            source: {
+              type: 'Literal',
+              value: module.source
+            }
+          })
+          .find(j.Literal)
+          .forEach((importLiteral) => {
+            j(importLiteral).replaceWith(j.literal(newSource))
+          });
+        }
       }
     })
   }

--- a/transforms/globals-to-ember-data-imports.js
+++ b/transforms/globals-to-ember-data-imports.js
@@ -166,16 +166,17 @@ function transform(file, api /*, options*/) {
     if (foundMapping) {
       let newSource = foundMapping.source;
       if (module.source !== newSource) {
-        root.find(j.ImportDeclaration, {
-          source: {
-            type: 'Literal',
-            value: module.source
-          }
-        })
-        .find(j.Literal)
-        .forEach((importLiteral) => {
-          j(importLiteral).replaceWith(j.literal(newSource))
-        });
+        root
+          .find(j.ImportDeclaration, {
+            source: {
+              type: 'Literal',
+              value: module.source
+            }
+          })
+          .find(j.Literal)
+          .forEach(importLiteral => {
+            j(importLiteral).replaceWith(j.literal(newSource));
+          });
       }
     }
   }
@@ -495,7 +496,7 @@ function transform(file, api /*, options*/) {
         }
       } else {
         // Update literal paths based on mappings from 'ember-data/model' to '@ember-data/model'
-        updateLiteralPaths(root, mod, mappings)
+        updateLiteralPaths(root, mod, mappings);
       }
     });
   }


### PR DESCRIPTION
This PR attempts to replace examples like `ember-data/model` with `@ember-data/model` based on the mappings here: https://github.com/ember-data/ember-data-rfc395-data

Moreover, I removed the beautify code. I'm not sure this codemod should be modifying these imports as show here - https://github.com/ember-codemods/ember-modules-codemod/issues/90.  If you would like, I can add this in a different PR.