### PR TITLE
follow-up: Update literal paths

### DIFF
--- a/__testfixtures__/literal.input.js
+++ b/__testfixtures__/literal.input.js
@@ -1,5 +1,5 @@
-import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
+import Model from 'ember-data/model';
 import { hasMany, belongsTo } from 'ember-data/relationships';
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
 import { InvalidError, ServerError, TimeoutError, NotFoundError  } from 'ember-data/adapter/error';


### PR DESCRIPTION
The [merged PR](https://github.com/ember-codemods/ember-data-codemod/pull/21) to support updating literal paths will require a few more work.

Here is a failing test to highlight a bug. The current implementation is order-sentitive.